### PR TITLE
read allowed in commandline metadata

### DIFF
--- a/panzer/cli.py
+++ b/panzer/cli.py
@@ -165,6 +165,7 @@ def pandoc_opt_parse(args):
     # general options
     opt_parser.add_argument("--data-dir")
     # reader options
+    opt_parser.add_argument('--read') # read allowed in commandline metadata 
     opt_parser.add_argument('--parse-raw', '-R', action='store_true')
     opt_parser.add_argument('--smart', '-S', action='store_true')
     opt_parser.add_argument('--old-dashes', action='store_true')

--- a/panzer/const.py
+++ b/panzer/const.py
@@ -38,7 +38,7 @@ PANDOC_BAD_OPTS = ['--dump-args',
 
 # forbidden options for 'commandline' metadata field
 PANDOC_BAD_COMMANDLINE = ['write',
-                          'read',
+                          #'read', # read allowed in commandline metadata
                           'from',
                           'to',
                           'filter',
@@ -69,6 +69,7 @@ PANDOC_OPT_PHASE = {# general options
                     # reader options
                     'parse-raw':               'r',
                     'smart':                   'r',
+                    'read':                    'r', # read allowed in commandline metadata
                     'old-dashes':              'r',
                     'base-header-level':       'r',
                     'indented-code-classes':   'r',

--- a/panzer/version.py
+++ b/panzer/version.py
@@ -1,2 +1,2 @@
 """ version of panzer """
-VERSION = "1.0"
+VERSION = "1.0+read.1"


### PR DESCRIPTION
Hi again, I have created a first version where the `read` option can be set in the style files. It works with an style entry like:

```
md-base:
    all:
        commandline:
            read: "`markdown+autolink_bare_uris+multiline_tables+table_captions+definition_lists`"
```

It doesn't have protection against use in none-markdown source files yet, but it's a start.
