### PR TITLE
Add AUR package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Installation
 
     pip3 install --upgrade git+https://github.com/msprev/panzer
 
+On Arch Linux systems, the AUR package
+[panzer-git](https://aur.archlinux.org/packages/panzer-git/) can be used.
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
I've created an AUR package at [panzer-git](https://aur.archlinux.org/packages/panzer-git/) for Arch Linux users, which should stay up-to-date automatically with the git version and references all necessary dependencies. It might be helpful to add a link to the README.
