### PR TITLE
Typos and deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ numbersections: true
 filter:
     - run: smallcaps.py
 commandline:
-    - latex-engine: "`xelatex`"
+    pdf-engine: "`xelatex`"
 ...
 ```
 
@@ -635,12 +635,12 @@ Pull requests welcome:
 # Release notes
 
   - 1.3 (7 November 2017):
-  - updated for pandoc 2.0
-    [\#31](https://github.com/msprev/panzer/issues/31). Please note that
-    this version of panzer *breaks compatibility with versions of pandoc
-    earlier than 2.0*. Please upgrade to a version of pandoc \>2.0.
-    Versions of pandoc prior to 2.0 will no longer be supported in
-    future releases of panzer.
+     -  updated for pandoc 2.0
+        [\#31](https://github.com/msprev/panzer/issues/31). Please note that
+        this version of panzer *breaks compatibility with versions of pandoc
+        earlier than 2.0*. Please upgrade to a version of pandoc \>2.0.
+        Versions of pandoc prior to 2.0 will no longer be supported in
+        future releases of panzer.
   - 1.2 (12 January 2017):
       - fixed issue introduced by breaking change in panzer 1.1
         [\#27](https://github.com/msprev/panzer/issues/27). Added panzer


### PR DESCRIPTION
* latex-engine is being replaced by pdf-engine and the `commandline` field should be of type `Metamap` and not `Metalist`.
* typo in the level of the text in the changelog.